### PR TITLE
Route generation feature "visit every xth line" implemented for even values of x.

### DIFF
--- a/Linux/RControlStation/mainwindow.cpp
+++ b/Linux/RControlStation/mainwindow.cpp
@@ -2204,19 +2204,20 @@ void MainWindow::on_boundsFillPushButton_clicked()
     QList<LocPoint> route;
     if (ui->generateFrameCheckBox->isChecked())
         route = RouteMagic::fillConvexPolygonWithFramedZigZag(bounds, spacing, ui->boundsFillSpacingTowardsBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
-                                                              ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(),
+                                                              ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(), ui->visitEverySpinBox->value(),
                                                               ui->lowerToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_DOWN : 0, ui->raiseToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_UP : 0,
                                                               ui->raiseToolsDistanceSpinBox->value()*2);
                                                               // attribute changes at half distance
     else
         route = RouteMagic::fillConvexPolygonWithZigZag(bounds, spacing, ui->boundsFillSpacingTowardsBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
-                                                        ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(),
+                                                        ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(), ui->visitEverySpinBox->value(),
                                                         ui->lowerToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_DOWN : 0, ui->raiseToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_UP : 0,
                                                         ui->raiseToolsDistanceSpinBox->value()*2);
 
     int r = ui->mapWidget->getRoutes().size();
     ui->mapWidget->addRoute(route);
     ui->mapWidget->setRouteNow(r);
+    ui->mapRouteBox->setValue(r);
     ui->mapWidget->repaint();
 
 }

--- a/Linux/RControlStation/mainwindow.cpp
+++ b/Linux/RControlStation/mainwindow.cpp
@@ -2203,19 +2203,19 @@ void MainWindow::on_boundsFillPushButton_clicked()
     //QList<LocPoint> test = RouteMagic::fillBoundsWithTrajectory(bounds, entry, exit, spacing, ang_rad, true);
     QList<LocPoint> route;
     if (ui->generateFrameCheckBox->isChecked())
-        route = RouteMagic::fillConvexPolygonWithFramedZigZag(bounds, spacing, ui->boundsFillSpacingTowardsBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
+        route = RouteMagic::fillConvexPolygonWithFramedZigZag(bounds, spacing, ui->boundsFillKeepTurnsInBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
                                                               ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(), ui->visitEverySpinBox->value(),
                                                               ui->lowerToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_DOWN : 0, ui->raiseToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_UP : 0,
                                                               ui->raiseToolsDistanceSpinBox->value()*2);
                                                               // attribute changes at half distance
     else
-        route = RouteMagic::fillConvexPolygonWithZigZag(bounds, spacing, ui->boundsFillSpacingTowardsBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
+        route = RouteMagic::fillConvexPolygonWithZigZag(bounds, spacing, ui->boundsFillKeepTurnsInBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
                                                         ui->boundsFillSpeedInTurnsSpinBox->value()/3.6, ui->stepsForTurningSpinBox->value(), ui->visitEverySpinBox->value(),
                                                         ui->lowerToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_DOWN : 0, ui->raiseToolsCheckBox->isChecked() ? ATTR_HYDRAULIC_FRONT_UP : 0,
                                                         ui->raiseToolsDistanceSpinBox->value()*2);
 
-    int r = ui->mapWidget->getRoutes().size();
     ui->mapWidget->addRoute(route);
+    int r = ui->mapWidget->getRoutes().size()-1;
     ui->mapWidget->setRouteNow(r);
     ui->mapRouteBox->setValue(r);
     ui->mapWidget->repaint();

--- a/Linux/RControlStation/mainwindow.cpp
+++ b/Linux/RControlStation/mainwindow.cpp
@@ -2165,42 +2165,13 @@ void MainWindow::on_setBoundsRoutePushButton_clicked()
     ui->boundsRouteSpinBox->setValue(r);
 }
 
-void MainWindow::on_setEntryRoutePushButton_clicked()
-{
-    int r = ui->mapWidget->getRouteNow();
-    ui->entryRouteSpinBox->setValue(r);
-}
-
-void MainWindow::on_setExitRoutePushButton_clicked()
-{
-    int r = ui->mapWidget->getRouteNow();
-    ui->exitRouteSpinBox->setValue(r);
-}
-
-void MainWindow::on_boundsFillAngleSlider_sliderMoved(int position)
-{
-
-    return;
-
-}
-
 void MainWindow::on_boundsFillPushButton_clicked()
 {
     QList<LocPoint> bounds = ui->mapWidget->getRoute(ui->boundsRouteSpinBox->value());
-    QList<LocPoint> entry  = ui->mapWidget->getRoute(ui->entryRouteSpinBox->value());
-    QList<LocPoint> exit   = ui->mapWidget->getRoute(ui->exitRouteSpinBox->value());
 
     double spacing = ui->boundsFillSpacingSpinBox->value();
     if (spacing < 0.5) return;
 
-    int    angle   = ui->boundsFillAngleSlider->value();
-    double ang_rad = static_cast<double>(angle) * M_PI / 180.0;
-    if (ui->findOptimalAngleCheckBox->checkState()) {
-        const auto lineForOptimalAngle = RouteMagic::getBaselineDeterminingMinHeightOfConvexPolygon(bounds);
-        ang_rad = atan2(lineForOptimalAngle.second.getY() - lineForOptimalAngle.first.getY(), lineForOptimalAngle.second.getX() - lineForOptimalAngle.first.getX()) + RouteMagic::PI/2;
-    }
-
-    //QList<LocPoint> test = RouteMagic::fillBoundsWithTrajectory(bounds, entry, exit, spacing, ang_rad, true);
     QList<LocPoint> route;
     if (ui->generateFrameCheckBox->isChecked())
         route = RouteMagic::fillConvexPolygonWithFramedZigZag(bounds, spacing, ui->boundsFillKeepTurnsInBoundsCheckBox->isChecked(), ui->boundsFillSpeedSpinBox->value()/3.6,
@@ -2220,36 +2191,6 @@ void MainWindow::on_boundsFillPushButton_clicked()
     ui->mapRouteBox->setValue(r);
     ui->mapWidget->repaint();
 
-}
-
-// TODO Code duplication (on_boundsFillPushButton_clicked())
-void MainWindow::on_boundsFillAngleSlider_sliderReleased()
-{
-    if (!ui->rotateActiveTrajectoryCheckBox->isChecked()) {
-        on_boundsFillPushButton_clicked();
-        return;
-    }
-    int rNow = ui->mapWidget->getRouteNow();
-    if (rNow == ui->entryRouteSpinBox->value() ||
-        rNow == ui->exitRouteSpinBox->value() ||
-        rNow == ui->boundsRouteSpinBox->value()) return;
-
-    ui->mapWidget->clearRoute();
-    QList<LocPoint> bounds = ui->mapWidget->getRoute(ui->boundsRouteSpinBox->value());
-    QList<LocPoint> entry  = ui->mapWidget->getRoute(ui->entryRouteSpinBox->value());
-    QList<LocPoint> exit   = ui->mapWidget->getRoute(ui->exitRouteSpinBox->value());
-    double spacing = ui->boundsFillSpacingSpinBox->value();
-    int    angle   = ui->boundsFillAngleSlider->value();
-    double ang_rad = static_cast<double>(angle) * M_PI / 180.0;
-    QList<LocPoint> test = RouteMagic::fillBoundsWithTrajectory(bounds, entry, exit, spacing, ang_rad, true);
-    ui->mapWidget->setRoute(test);
-}
-
-void MainWindow::on_findOptimalAngleCheckBox_stateChanged(int checkState)
-{
-    ui->boundsFillAngleSlider->setEnabled(!checkState);
-    ui->boundsFillAngleLabel->setEnabled(!checkState);
-    ui->rotateActiveTrajectoryCheckBox->setEnabled(!checkState);
 }
 
 void MainWindow::on_lowerToolsCheckBox_stateChanged(int arg1)

--- a/Linux/RControlStation/mainwindow.h
+++ b/Linux/RControlStation/mainwindow.h
@@ -176,15 +176,7 @@ private slots:
     void on_mapRoutePosAttrBox_currentIndexChanged(int index);
     void on_clearAnchorButton_clicked();
     void on_setBoundsRoutePushButton_clicked();
-    void on_setEntryRoutePushButton_clicked();
-    void on_setExitRoutePushButton_clicked();
-    void on_boundsFillAngleSlider_sliderMoved(int position);
-
     void on_boundsFillPushButton_clicked();
-
-    void on_boundsFillAngleSlider_sliderReleased();
-
-    void on_findOptimalAngleCheckBox_stateChanged(int checkState);
 
     void on_lowerToolsCheckBox_stateChanged(int arg1);
 

--- a/Linux/RControlStation/mainwindow.ui
+++ b/Linux/RControlStation/mainwindow.ui
@@ -2194,8 +2194,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>229</width>
-                     <height>940</height>
+                     <width>206</width>
+                     <height>880</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -2878,69 +2878,6 @@
                         </layout>
                        </item>
                        <item>
-                        <layout class="QHBoxLayout" name="horizontalLayout_18">
-                         <property name="spacing">
-                          <number>6</number>
-                         </property>
-                         <item>
-                          <widget class="QSpinBox" name="entryRouteSpinBox">
-                           <property name="enabled">
-                            <bool>false</bool>
-                           </property>
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="prefix">
-                            <string>Entry: </string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QPushButton" name="setEntryRoutePushButton">
-                           <property name="enabled">
-                            <bool>false</bool>
-                           </property>
-                           <property name="text">
-                            <string>Use Active</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </item>
-                       <item>
-                        <layout class="QHBoxLayout" name="horizontalLayout_19">
-                         <item>
-                          <widget class="QSpinBox" name="exitRouteSpinBox">
-                           <property name="enabled">
-                            <bool>false</bool>
-                           </property>
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="prefix">
-                            <string>Exit: </string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QPushButton" name="setExitRoutePushButton">
-                           <property name="enabled">
-                            <bool>false</bool>
-                           </property>
-                           <property name="text">
-                            <string>Use Active</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </item>
-                       <item>
                         <spacer name="verticalSpacer_8">
                          <property name="orientation">
                           <enum>Qt::Vertical</enum>
@@ -3021,22 +2958,6 @@
                         </widget>
                        </item>
                        <item>
-                        <spacer name="verticalSpacer_12">
-                         <property name="orientation">
-                          <enum>Qt::Vertical</enum>
-                         </property>
-                         <property name="sizeType">
-                          <enum>QSizePolicy::Fixed</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>20</width>
-                           <height>5</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                       <item>
                         <widget class="QSpinBox" name="visitEverySpinBox">
                          <property name="suffix">
                           <string> Row</string>
@@ -3049,16 +2970,6 @@
                          </property>
                          <property name="singleStep">
                           <number>2</number>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QSpinBox" name="stepsForTurningSpinBox">
-                         <property name="prefix">
-                          <string>Steps For Turning: </string>
-                         </property>
-                         <property name="value">
-                          <number>6</number>
                          </property>
                         </widget>
                        </item>
@@ -3146,29 +3057,6 @@
                         </widget>
                        </item>
                        <item>
-                        <spacer name="verticalSpacer_10">
-                         <property name="orientation">
-                          <enum>Qt::Vertical</enum>
-                         </property>
-                         <property name="sizeType">
-                          <enum>QSizePolicy::Fixed</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>20</width>
-                           <height>5</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                       <item>
-                        <widget class="QCheckBox" name="generateFrameCheckBox">
-                         <property name="text">
-                          <string>Gen. Frame around ZigZag</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
                         <spacer name="verticalSpacer_9">
                          <property name="orientation">
                           <enum>Qt::Vertical</enum>
@@ -3186,77 +3074,30 @@
                        </item>
                        <item>
                         <widget class="QGroupBox" name="groupBox_21">
-                         <property name="enabled">
+                         <property name="title">
+                          <string>Expert / Experimental</string>
+                         </property>
+                         <property name="flat">
                           <bool>false</bool>
                          </property>
-                         <property name="title">
-                          <string>Angle</string>
+                         <property name="checkable">
+                          <bool>false</bool>
                          </property>
                          <layout class="QVBoxLayout" name="verticalLayout_29">
                           <item>
-                           <widget class="QCheckBox" name="findOptimalAngleCheckBox">
-                            <property name="enabled">
-                             <bool>false</bool>
+                           <widget class="QSpinBox" name="stepsForTurningSpinBox">
+                            <property name="prefix">
+                             <string>Steps For Turning: </string>
                             </property>
-                            <property name="text">
-                             <string>Find Optimal Angle</string>
-                            </property>
-                            <property name="checked">
-                             <bool>true</bool>
-                            </property>
-                            <property name="tristate">
-                             <bool>false</bool>
+                            <property name="value">
+                             <number>6</number>
                             </property>
                            </widget>
                           </item>
                           <item>
-                           <widget class="QLabel" name="boundsFillAngleLabel">
-                            <property name="enabled">
-                             <bool>false</bool>
-                            </property>
+                           <widget class="QCheckBox" name="generateFrameCheckBox">
                             <property name="text">
-                             <string>Choose Angle:</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QSlider" name="boundsFillAngleSlider">
-                            <property name="enabled">
-                             <bool>false</bool>
-                            </property>
-                            <property name="layoutDirection">
-                             <enum>Qt::RightToLeft</enum>
-                            </property>
-                            <property name="minimum">
-                             <number>0</number>
-                            </property>
-                            <property name="maximum">
-                             <number>360</number>
-                            </property>
-                            <property name="orientation">
-                             <enum>Qt::Horizontal</enum>
-                            </property>
-                            <property name="invertedAppearance">
-                             <bool>true</bool>
-                            </property>
-                            <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
-                            </property>
-                            <property name="tickInterval">
-                             <number>90</number>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QCheckBox" name="rotateActiveTrajectoryCheckBox">
-                            <property name="enabled">
-                             <bool>false</bool>
-                            </property>
-                            <property name="text">
-                             <string>Rotate Active</string>
-                            </property>
-                            <property name="checked">
-                             <bool>true</bool>
+                             <string>Gen. Frame around ZigZag</string>
                             </property>
                            </widget>
                           </item>

--- a/Linux/RControlStation/mainwindow.ui
+++ b/Linux/RControlStation/mainwindow.ui
@@ -44,7 +44,7 @@
            <x>0</x>
            <y>0</y>
            <width>180</width>
-           <height>68</height>
+           <height>80</height>
           </rect>
          </property>
          <attribute name="label">
@@ -105,7 +105,7 @@
            <x>0</x>
            <y>0</y>
            <width>180</width>
-           <height>88</height>
+           <height>108</height>
           </rect>
          </property>
          <attribute name="label">
@@ -210,8 +210,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>181</width>
-           <height>71</height>
+           <width>184</width>
+           <height>80</height>
           </rect>
          </property>
          <attribute name="label">
@@ -1284,8 +1284,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>213</width>
-                     <height>749</height>
+                     <width>191</width>
+                     <height>872</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1899,8 +1899,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>196</width>
-                     <height>436</height>
+                     <width>168</width>
+                     <height>483</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2194,8 +2194,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>210</width>
-                     <height>783</height>
+                     <width>229</width>
+                     <height>940</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -2786,8 +2786,17 @@
                 </property>
                 <item>
                  <widget class="QScrollArea" name="scrollArea_4">
+                  <property name="minimumSize">
+                   <size>
+                    <width>260</width>
+                    <height>0</height>
+                   </size>
+                  </property>
                   <property name="horizontalScrollBarPolicy">
                    <enum>Qt::ScrollBarAlwaysOff</enum>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QAbstractScrollArea::AdjustIgnored</enum>
                   </property>
                   <property name="widgetResizable">
                    <bool>true</bool>
@@ -2797,8 +2806,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>252</width>
-                     <height>619</height>
+                     <width>256</width>
+                     <height>940</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -3012,22 +3021,6 @@
                         </widget>
                        </item>
                        <item>
-                        <widget class="QCheckBox" name="boundsFillSpacingTowardsBoundsCheckBox">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <property name="text">
-                          <string>Spacing towards Bounds</string>
-                         </property>
-                         <property name="checked">
-                          <bool>false</bool>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
                         <spacer name="verticalSpacer_12">
                          <property name="orientation">
                           <enum>Qt::Vertical</enum>
@@ -3044,12 +3037,44 @@
                         </spacer>
                        </item>
                        <item>
+                        <widget class="QSpinBox" name="visitEverySpinBox">
+                         <property name="suffix">
+                          <string> Row</string>
+                         </property>
+                         <property name="prefix">
+                          <string>Visit Every </string>
+                         </property>
+                         <property name="maximum">
+                          <number>100</number>
+                         </property>
+                         <property name="singleStep">
+                          <number>2</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
                         <widget class="QSpinBox" name="stepsForTurningSpinBox">
                          <property name="prefix">
                           <string>Steps For Turning: </string>
                          </property>
                          <property name="value">
                           <number>5</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QCheckBox" name="boundsFillSpacingTowardsBoundsCheckBox">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Keep Turns within Bounds</string>
+                         </property>
+                         <property name="checked">
+                          <bool>false</bool>
                          </property>
                         </widget>
                        </item>
@@ -3434,7 +3459,7 @@
      <x>0</x>
      <y>0</y>
      <width>1561</width>
-     <height>22</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuHelp">

--- a/Linux/RControlStation/mainwindow.ui
+++ b/Linux/RControlStation/mainwindow.ui
@@ -3058,12 +3058,12 @@
                           <string>Steps For Turning: </string>
                          </property>
                          <property name="value">
-                          <number>5</number>
+                          <number>6</number>
                          </property>
                         </widget>
                        </item>
                        <item>
-                        <widget class="QCheckBox" name="boundsFillSpacingTowardsBoundsCheckBox">
+                        <widget class="QCheckBox" name="boundsFillKeepTurnsInBoundsCheckBox">
                          <property name="sizePolicy">
                           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                            <horstretch>0</horstretch>

--- a/Linux/RControlStation/routemagic.h
+++ b/Linux/RControlStation/routemagic.h
@@ -76,8 +76,8 @@ public:
     static QList<LocPoint> generateRouteWithin(int length, QList<LocPoint> prev_traj, double speed, QList<LocPoint> outerFence, QList<QList<LocPoint> > cutouts);
 
     static QList<LocPoint> fillBoundsWithTrajectory(QList<LocPoint> bounds, QList<LocPoint> entry, QList<LocPoint> exit, double spacing, double angle, bool reduce);
-    static QList<LocPoint> fillConvexPolygonWithZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
-    static QList<LocPoint> fillConvexPolygonWithFramedZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
+    static QList<LocPoint> fillConvexPolygonWithZigZag(QList<LocPoint> bounds, double spacing, bool keepTurnsInBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
+    static QList<LocPoint> fillConvexPolygonWithFramedZigZag(QList<LocPoint> bounds, double spacing, bool keepTurnsInBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
     static QList<LocPoint> getShrinkedConvexPolygon(QList<LocPoint> bounds, double spacing);
     static int getConvexPolygonOrientation(QList<LocPoint> bounds);
 

--- a/Linux/RControlStation/routemagic.h
+++ b/Linux/RControlStation/routemagic.h
@@ -76,8 +76,8 @@ public:
     static QList<LocPoint> generateRouteWithin(int length, QList<LocPoint> prev_traj, double speed, QList<LocPoint> outerFence, QList<QList<LocPoint> > cutouts);
 
     static QList<LocPoint> fillBoundsWithTrajectory(QList<LocPoint> bounds, QList<LocPoint> entry, QList<LocPoint> exit, double spacing, double angle, bool reduce);
-    static QList<LocPoint> fillConvexPolygonWithZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
-    static QList<LocPoint> fillConvexPolygonWithFramedZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
+    static QList<LocPoint> fillConvexPolygonWithZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
+    static QList<LocPoint> fillConvexPolygonWithFramedZigZag(QList<LocPoint> bounds, double spacing, bool spacingTowardsBounds = false, double speed = 3.0/3.6, double speedInTurns = 2.0/3.6, int turnIntermediateSteps = 0, int visitEveryX = 0, uint32_t setAttributesOnStraights = 0, uint32_t setAttributesInTurns = 0, double pointWithAttributesDistanceToTurn = 1.0);
     static QList<LocPoint> getShrinkedConvexPolygon(QList<LocPoint> bounds, double spacing);
     static int getConvexPolygonOrientation(QList<LocPoint> bounds);
 


### PR DESCRIPTION
- Currently, the route goes back to origin after going over the whole field to visit the rows not yet visited.
- The option to generate the route with distance to the bounds has been remove (to be revised)
- By default, the turns in the route will not adhere to the bounds. Optionally, they do. This is in preparation of implementing headland support (vändteg/Vorgewende).