### PR TITLE
Feature commandline basestation

### DIFF
--- a/Linux/RControlStation/RControlStation.pro
+++ b/Linux/RControlStation/RControlStation.pro
@@ -41,6 +41,8 @@ win32: LIBS += -lOpengl32
 TARGET = RControlStation
 TEMPLATE = app
 
+CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
+
 release_win {
     DESTDIR = build/win
     OBJECTS_DIR = build/win/obj

--- a/Linux/RControlStation/RControlStation.pro
+++ b/Linux/RControlStation/RControlStation.pro
@@ -109,7 +109,8 @@ SOURCES += main.cpp\
     historylineedit.cpp \
     imagewidget.cpp \
     tcpclientmulti.cpp \
-    routemagic.cpp
+    routemagic.cpp \
+    task_basestation.cpp
 
 HEADERS  += mainwindow.h \
     qcustomplot.h \
@@ -149,7 +150,9 @@ HEADERS  += mainwindow.h \
     imagewidget.h \
     tcpclientmulti.h \
     routemagic.h \
-    attributes_masks.h
+    attributes_masks.h \
+    task.h \
+    task_basestation.h
 
 FORMS    += mainwindow.ui \
     carinterface.ui \

--- a/Linux/RControlStation/basestation.cpp
+++ b/Linux/RControlStation/basestation.cpp
@@ -510,7 +510,7 @@ void BaseStation::on_ubxSerialDisconnectButton_clicked()
     mUblox->disconnectSerial();
 }
 
-void BaseStation::configureUbx(Ublox* ublox, int rate, bool isF9p, bool isM8p, bool surveyIn, double surveyInMinAcc, bool* basePosSet, double refSendLat, double refSendLon, double refSendH)
+void BaseStation::configureUbx(Ublox* ublox, int rate, bool isF9p, bool isM8p, bool* basePosSet, double refSendLat, double refSendLon, double refSendH, bool surveyIn, double surveyInMinAcc, int surveyInMinDuration)
 {
     // Serial port baud rate
     // if it is too low the buffer will overfill and it won't work properly.
@@ -523,7 +523,7 @@ void BaseStation::configureUbx(Ublox* ublox, int rate, bool isF9p, bool isM8p, b
     uart.out_ubx = true;
     uart.out_nmea = true;
     uart.out_rtcm3 = true;
-//    qDebug() << "CfgPrtUart:" << ublox->ubxCfgPrtUart(&uart);
+/*    qDebug() << "CfgPrtUart:" << */ublox->ubxCfgPrtUart(&uart);
 
     ublox->ubxCfgRate(rate, 1, 0);
 
@@ -608,7 +608,7 @@ void BaseStation::configureUbx(Ublox* ublox, int rate, bool isF9p, bool isM8p, b
     memset(&cfg_mode, 0, sizeof(cfg_mode));
     cfg_mode.mode = isF9p ? 1 : 0;
     cfg_mode.fixed_pos_acc = 5.0;
-    cfg_mode.svin_min_dur = 20;
+    cfg_mode.svin_min_dur = surveyInMinDuration;
     cfg_mode.svin_acc_limit = surveyInMinAcc;
 
     if (!surveyIn && isF9p) {
@@ -701,7 +701,7 @@ void BaseStation::on_ubxSerialConnectButton_clicked()
         double refSendLon = ui->refSendLonBox->value();
         double refSendH = ui->refSendHBox->value();
 
-        configureUbx(mUblox, rate, isF9p, isM8p, surveyIn, surveyInMinAcc, &mBasePosSet, refSendLat, refSendLon, refSendH);
+        configureUbx(mUblox, rate, isF9p, isM8p, &mBasePosSet, refSendLat, refSendLon, refSendH, surveyIn, surveyInMinAcc);
     }
 }
 

--- a/Linux/RControlStation/basestation.cpp
+++ b/Linux/RControlStation/basestation.cpp
@@ -578,11 +578,12 @@ void BaseStation::on_ubxSerialConnectButton_clicked()
             mUblox->ubloxCfgAppendEnableGlo(buffer, &ind, true, true, true);
             mUblox->ubloxCfgValset(buffer, ind, true, true, true);
 
-            ind = 0;
-            mUblox->ubloxCfgAppendUart1Baud(buffer, &ind, 115200);
-            mUblox->ubloxCfgAppendUart1InProt(buffer, &ind, true, true, true);
-            mUblox->ubloxCfgAppendUart1OutProt(buffer, &ind, true, true, true);
-            qDebug() << "UART Config:" << mUblox->ubloxCfgValset(buffer, ind, true, true, true);
+//          NOTE: set baudrate STM <-> UBX over USB, should not be necessary
+//            ind = 0;
+//            mUblox->ubloxCfgAppendUart1Baud(buffer, &ind, 115200);
+//            mUblox->ubloxCfgAppendUart1InProt(buffer, &ind, true, true, true);
+//            mUblox->ubloxCfgAppendUart1OutProt(buffer, &ind, true, true, true);
+//            qDebug() << "UBX UART1 Config:" << mUblox->ubloxCfgValset(buffer, ind, true, true, true);
         } else {
             ubx_cfg_nmea nmea;
             memset(&nmea, 0, sizeof(ubx_cfg_nmea));

--- a/Linux/RControlStation/basestation.cpp
+++ b/Linux/RControlStation/basestation.cpp
@@ -523,7 +523,7 @@ void BaseStation::configureUbx(Ublox* ublox, int rate, bool isF9p, bool isM8p, b
     uart.out_ubx = true;
     uart.out_nmea = true;
     uart.out_rtcm3 = true;
-    qDebug() << "CfgPrtUart:" << ublox->ubxCfgPrtUart(&uart);
+//    qDebug() << "CfgPrtUart:" << ublox->ubxCfgPrtUart(&uart);
 
     ublox->ubxCfgRate(rate, 1, 0);
 

--- a/Linux/RControlStation/basestation.h
+++ b/Linux/RControlStation/basestation.h
@@ -39,7 +39,7 @@ public:
     ~BaseStation();
     void setMap(MapWidget *map);
 
-    static void configureUbx(Ublox *ublox, int rate, bool isF9p, bool isM8p, bool surveyIn, double surveyInMinAcc, bool *basePosSet, double refSendLat, double refSendLon, double refSendH);
+    static void configureUbx(Ublox *ublox, int rate, bool isF9p, bool isM8p, bool *basePosSet, double refSendLat, double refSendLon, double refSendH, bool surveyIn, double surveyInMinAcc, int surveyInMinDuration = 20);
 
 signals:
     void rtcmOut(QByteArray data);

--- a/Linux/RControlStation/basestation.h
+++ b/Linux/RControlStation/basestation.h
@@ -39,6 +39,8 @@ public:
     ~BaseStation();
     void setMap(MapWidget *map);
 
+    static void configureUbx(Ublox *ublox, int rate, bool isF9p, bool isM8p, bool surveyIn, double surveyInMinAcc, bool *basePosSet, double refSendLat, double refSendLon, double refSendH);
+
 signals:
     void rtcmOut(QByteArray data);
 

--- a/Linux/RControlStation/main.cpp
+++ b/Linux/RControlStation/main.cpp
@@ -25,22 +25,22 @@
 
 void showHelp()
 {
-    qDebug() << "Arguments";
-    qDebug() << "-h, --help : Show help text";
-    qDebug() << "--basestation : Run RTK GNSS basestation on command line";
-    qDebug() << "--plotroutes [xmlFile] : Plot routes from XML file";
-    qDebug() << "--plotroutessize [w]:[h] : Size to plot with in pixels";
-    qDebug() << "--plotroutesformat [format] : plot format; PDF or PNG";
-    qDebug() << "--plotroutesmargins [margins] : Margins around the plot";
-    qDebug() << "--plotroutesselect [id] : Select route with id";
-    qDebug() << "--plotroutesshowgrid : Show grid in plot";
-    qDebug() << "--plotroutesshowtext : Show text next to route points";
-    qDebug() << "--addcar [id]:[pollData] : Add car tab with car id";
-    qDebug() << "--connectjs [dev] : Connect to joystick dev (e.g. /dev/input/js0)";
-    qDebug() << "--connecttcp [ip]:[port] : Connect to car over TCP (multiple connections possible)";
-    qDebug() << "--xmltcpserver [port] : Run XML TCP server on port";
-    qDebug() << "--xmludpserver [port] : Run XML UDP server on port";
-    qDebug() << "--loadroutes [xmlFile] : Load routes from XML file";
+    std::cout << "Arguments" << std::endl;
+    std::cout << "-h, --help : Show help text" << std::endl;
+    std::cout << "--basestation [surveyInMinDuration:[surveyInMinAcc:[tcpPort:[ubxSerialPort:[baudrate]]]]] : Run RTK GNSS basestation on command line" << std::endl;
+    std::cout << "--plotroutes xmlFile : Plot routes from XML file" << std::endl;
+    std::cout << "--plotroutessize w:h : Size to plot with in pixels" << std::endl;
+    std::cout << "--plotroutesformat format : plot format; PDF or PNG" << std::endl;
+    std::cout << "--plotroutesmargins margins : Margins around the plot" << std::endl;
+    std::cout << "--plotroutesselect id : Select route with id" << std::endl;
+    std::cout << "--plotroutesshowgrid : Show grid in plot" << std::endl;
+    std::cout << "--plotroutesshowtext : Show text next to route points" << std::endl;
+    std::cout << "--addcar id[:pollData] : Add car tab with car id" << std::endl;
+    std::cout << "--connectjs dev : Connect to joystick dev (e.g. /dev/input/js0)" << std::endl;
+    std::cout << "--connecttcp ip[:port] : Connect to car over TCP (multiple connections possible)" << std::endl;
+    std::cout << "--xmltcpserver port : Run XML TCP server on port" << std::endl;
+    std::cout << "--xmludpserver port : Run XML UDP server on port" << std::endl;
+    std::cout << "--loadroutes xmlFile : Load routes from XML file" << std::endl;
 }
 
 int main(int argc, char *argv[])
@@ -87,6 +87,13 @@ int main(int argc, char *argv[])
     int xmlUdpPort = -2;
     QString loadRoutesFile;
 
+    // Commandline basestation parameters
+    int surveyInMinDuration = 300; // 5 minutes
+    double surveyInMinAcc = 2.0; // 2 meters
+    int tcpPort = 2101;
+    QString ubxSerialPort;
+    int ubxBaudrate = 115200;
+
     for (int i = 0;i < args.size();i++) {
         // Skip the program argument
         if (i == 0) {
@@ -113,6 +120,21 @@ int main(int argc, char *argv[])
             noGui = true;
             run_mode = RUN_BASESTATION;
             found = true;
+            if ((i + 1) < args.size()) {
+                i++;
+                QStringList modeArgs = args.at(i).split(":");
+
+                surveyInMinDuration = modeArgs.at(0).toInt();
+                if (modeArgs.size() >= 2)
+                    surveyInMinAcc = modeArgs.at(1).toDouble();
+                if (modeArgs.size() >= 3)
+                    tcpPort = modeArgs.at(2).toInt();
+                if (modeArgs.size() >= 4)
+                    ubxSerialPort = modeArgs.at(3);
+                if (modeArgs.size() >= 5)
+                    ubxBaudrate = modeArgs.at(4).toInt();
+
+            }
         }
 
         if (str == "--plotroutes") {
@@ -351,7 +373,7 @@ int main(int argc, char *argv[])
         }
     } else {
         switch (run_mode) {
-        case RUN_BASESTATION: task.reset(new Task_BaseStation(a.get())); break;
+        case RUN_BASESTATION: task.reset(new Task_BaseStation(a.get(), surveyInMinDuration, surveyInMinAcc, tcpPort, ubxSerialPort, ubxBaudrate)); break;
         default: break;
         }
         QObject::connect(task.get(), SIGNAL(finished()), a.get(), SLOT(quit()));

--- a/Linux/RControlStation/main.cpp
+++ b/Linux/RControlStation/main.cpp
@@ -351,7 +351,7 @@ int main(int argc, char *argv[])
         }
     } else {
         switch (run_mode) {
-        case RUN_BASESTATION: task.reset(new BaseStationTask(a.get())); break;
+        case RUN_BASESTATION: task.reset(new Task_BaseStation(a.get())); break;
         default: break;
         }
         QObject::connect(task.get(), SIGNAL(finished()), a.get(), SLOT(quit()));

--- a/Linux/RControlStation/task.h
+++ b/Linux/RControlStation/task.h
@@ -17,7 +17,6 @@ public slots:
     void run()
     {
         task();
-        //emit finished();
     }
 
 signals:

--- a/Linux/RControlStation/task.h
+++ b/Linux/RControlStation/task.h
@@ -11,13 +11,13 @@ public:
     Task(QObject *parent = 0) : QObject(parent) {}
 
 private:
-    virtual void task() = 0;
+    virtual void task() = 0; // the actual work to be performed
 
 public slots:
     void run()
     {
         task();
-        emit finished();
+        //emit finished();
     }
 
 signals:

--- a/Linux/RControlStation/task.h
+++ b/Linux/RControlStation/task.h
@@ -1,0 +1,27 @@
+#ifndef TASK_H
+#define TASK_H
+
+#include <QObject>
+
+// abstract class used to implement commandline-based modes
+class Task : public QObject
+{
+    Q_OBJECT
+public:
+    Task(QObject *parent = 0) : QObject(parent) {}
+
+private:
+    virtual void task() = 0;
+
+public slots:
+    void run()
+    {
+        task();
+        emit finished();
+    }
+
+signals:
+    void finished();
+};
+
+#endif // TASK_H

--- a/Linux/RControlStation/task_basestation.cpp
+++ b/Linux/RControlStation/task_basestation.cpp
@@ -1,33 +1,210 @@
 #include "task_basestation.h"
 #include "basestation.h"
+#include "utility.h"
 #include <QDebug>
+#include <QJsonObject>
+#include <QJsonDocument>
 
+#define RTCM_REF_MSG_DELAY_MULT 5
+
+void Task_BaseStation::getExternalIp()
+{
+    QUrl url("https://api.ipify.org?format=json");
+    mExtIPstring = "testing...";
+
+    connect(mNetworkAccessManager.get(), &QNetworkAccessManager::finished, [&](QNetworkReply* reply){
+        reply->deleteLater();
+
+        if (reply->error()) {
+            mExtIPstring = "Uknown.";
+        } else {
+            QJsonObject jsonObject = QJsonDocument::fromJson(reply->readAll()).object();
+            QHostAddress ip(jsonObject["ip"].toString());
+
+            mExtIPstring = ip.toString();
+        }
+    });
+
+    mNetworkAccessManager->get(QNetworkRequest(url));
+}
 
 void Task_BaseStation::task()
 {
-//    qDebug() << "hello";
-//    printf("%c[1A", 033); // back one line
-//    printf("test");
-
     // TODO: parameterize from CLI
     QString serialPort = "ttyACM0";
     int baudrate = 115200;
     int rate = 1000;
-    bool surveyIn = false;
     double surveyInMinAcc = 2.0;
-    double refSendLat = 0;
+    double refSendLat = -90;
     double refSendLon = 0;
-    double refSendH = 0;
+    double refSendH = -5000;
     bool isM8p = false;
     bool isF9p = true;
-    bool mBasePosSet = false;
+    bool mBasePosSet = false;    
 
-
-    bool res = mUblox.connectSerial(serialPort, baudrate);
-    qDebug() << "Connection to UBX: " << res;
-    if (res) {
-        BaseStation::configureUbx(&mUblox, rate, isF9p, isM8p, surveyIn, surveyInMinAcc, &mBasePosSet, refSendLat, refSendLon, refSendH);
+    if (!mUblox.connectSerial(serialPort, baudrate)) {
+        std::cerr << "Unable to connect serial to " << serialPort.toStdString() << ". Exiting.\n";
+        emit finished();
     }
 
-    emit finished();
+    qDebug() << "Serial connection to " << serialPort << " established.";
+    mUBXCommTimer.start(500);
+    BaseStation::configureUbx(&mUblox, rate, isF9p, isM8p, mSurveyIn, surveyInMinAcc, &mBasePosSet, refSendLat, refSendLon, refSendH);
+
+    mUblox.ubxPoll(UBX_CLASS_MON, UBX_MON_VER);
+    mUblox.ubxPoll(UBX_CLASS_CFG, UBX_CFG_GNSS);    
+
+    // Wait for UBX messages to arrive, proceed only then
+    mUBXCommWaitLoop.exec();
+    mUBXCommTimer.stop();
+
+    if (mPrintMonVer)
+    std::cout << mMonVerString.toStdString() << std::endl;
+    if (mPrintCfgGnss)
+        std::cout << mCfgGnssString.toStdString() << std::endl;
+    std::cout << std::endl;
+
+    connect(&mUblox, &Ublox::rxNavSat, this, &Task_BaseStation::rxNavSat);
+    connect(&mUblox, &Ublox::rxSvin,   this, &Task_BaseStation::rxSvin);
+    connect(&mUblox, &Ublox::rtcmRx,   this, &Task_BaseStation::rtcmRx);
+
+    mNetworkAccessManager.reset(new QNetworkAccessManager(this));
+    getExternalIp();
+
+    mUpdateConsoleTimer.start(500);
+
+    mTcpServer.startTcpServer(mTcpServerPort);
+}
+
+void Task_BaseStation::rxMonVer(QString sw, QString hw, QStringList extensions)
+{
+    mMonVerString = "SW: " + sw + "\tHW: " + hw + "\tExtensions: ";
+    mMonVerString += extensions.join(", ");
+    if (!mCfgGnssString.isEmpty())
+        emit gotAllInitInfo();
+}
+
+void Task_BaseStation::rxCfgGnss(ubx_cfg_gnss cfg)
+{
+    mCfgGnssString = QString("TrkChHw   : %1\t TrkChUse  : %2\t Blocks    : %3\n").
+            arg(cfg.num_ch_hw).arg(cfg.num_ch_use).arg(cfg.num_blocks);
+
+    for (int i = 0;i < cfg.num_blocks;i++) {
+        mCfgGnssString += QString("GNSS ID: %1, Enabled: %2\t"
+                       "MinTrkCh  : %3\t"
+                       "MaxTrkCh  : %4\t"
+                       "Flags     : %5").
+                arg(cfg.blocks[i].gnss_id).
+                arg(cfg.blocks[i].en).
+                arg(cfg.blocks[i].minTrkCh).
+                arg(cfg.blocks[i].maxTrkCh).
+                arg(cfg.blocks[i].flags);
+
+        if (i != cfg.num_blocks - 1) {
+            mCfgGnssString += "\n";
+        }
+    }
+
+    if (!mMonVerString.isEmpty())
+        emit gotAllInitInfo();
+}
+
+void Task_BaseStation::rxNavSat(ubx_nav_sat satellites)
+{
+    memset(&mSatInfo, 0, sizeof(SatInfo));
+
+    for (int i = 0;i < satellites.num_sv;i++) {
+        ubx_nav_sat_info sat = satellites.sats[i];
+
+        switch (sat.gnss_id) {
+        case 0: mSatInfo.gpsVisible++; if (sat.used && sat.quality >= 4) mSatInfo.gpsUsed++; break;
+        case 2: mSatInfo.galVisible++; if (sat.used && sat.quality >= 4) mSatInfo.galUsed++; break;
+        case 3: mSatInfo.bdsVisible++; if (sat.used && sat.quality >= 4) mSatInfo.bdsUsed++; break;
+        case 6: mSatInfo.gloVisible++; if (sat.used && sat.quality >= 4) mSatInfo.gloUsed++; break;
+        default: break;
+        }
+    }
+}
+
+void Task_BaseStation::rxSvin(ubx_nav_svin svin)
+{
+    double llh[3];
+    utility::xyzToLlh(svin.meanX, svin.meanY, svin.meanZ,
+                      &llh[0], &llh[1], &llh[2]);
+
+    memcpy(mRefSendllh, llh, sizeof(double[3]));
+    mLastSvin = svin;
+}
+
+void Task_BaseStation::rtcmRx(QByteArray data, int type)
+{
+    // Send base station position every RTCM_REF_MSG_DELAY_MULT cycles to save bandwidth.
+    static int basePosCnt = 0;
+    if (type == 1006 || type == 1005) {
+        basePosCnt++;
+        if (basePosCnt < RTCM_REF_MSG_DELAY_MULT)
+            return;
+        basePosCnt = 0;
+    }
+
+    mRtcmUbx[type]++;
+    if (mTcpServer.isRunning()) {
+        mTcpServer.broadcastData(data);
+    }
+}
+
+void Task_BaseStation::updateConsoleOutput()
+{
+    QString surveyInfoString = QString(
+        "RTK Reference Station. Sending RTCM3 on port %1. External IP: %10         \n"
+        "----------------------------------------------------------------------------------------------\n"
+        "Position  - Lat: %2   Lon: %3   Height: %4          \n"
+        "Survey-In - Valid: %8   Active: %9   Duration: %7s   Accuracy: %6m   Observations: %5         \n"
+        "----------------------------------------------------------------------------------------------\n").
+        arg(mTcpServerPort).
+        arg(mRefSendllh[0], 0, 'f', 8).
+        arg(mRefSendllh[1], 0, 'f', 8).
+        arg(mRefSendllh[2]).
+        arg(mLastSvin.obs).
+        arg(mLastSvin.meanAcc).
+        arg(mLastSvin.dur).
+        arg(mLastSvin.valid).
+        arg(mLastSvin.active).
+        arg(mExtIPstring);
+
+    QString satInfoString = QString(
+        "Satellite Info.\n"
+        "GPS\t-\t%2 / %1   used / visible          \n"
+        "Galileo\t-\t%4 / %3   used / visible          \n"
+        "BeiDou\t-\t%6 / %5   used / visible          \n"
+        "GLONASS\t-\t%8 / %7   used / visible          \n"
+        "Total\t-\t%10 / %9   used / visible         \n"
+        "----------------------------------------------------------------------------------------------\n").
+            arg(mSatInfo.gpsVisible, 3).
+            arg(mSatInfo.gpsUsed, 3).
+            arg(mSatInfo.galVisible, 3).
+            arg(mSatInfo.galUsed, 3).
+            arg(mSatInfo.bdsVisible, 3).
+            arg(mSatInfo.bdsUsed, 3).
+            arg(mSatInfo.gloVisible, 3).
+            arg(mSatInfo.gloUsed, 3).
+            arg(mSatInfo.gpsVisible+mSatInfo.galVisible+mSatInfo.bdsVisible+mSatInfo.gloVisible, 3).
+            arg(mSatInfo.gpsUsed+mSatInfo.galUsed+mSatInfo.bdsUsed+mSatInfo.gloUsed, 3);
+
+    QString rtcmTransmittedString = QString(
+                "RTCM Transmitted:");
+
+    for (int i = 0; i < mRtcmUbx.size(); i++) {
+        if (i%5 == 0)
+            rtcmTransmittedString += "\n ";
+        rtcmTransmittedString += QString("%1 sent:%2   ").arg(mRtcmUbx.keys()[i]).arg(mRtcmUbx.values()[i], 6);
+    }
+
+    consoleOutputString = surveyInfoString + satInfoString + rtcmTransmittedString;
+
+    static int lastNumLines = 0;
+    if (lastNumLines != 0) // go back to beginning
+        printf("%c[%dA",  033, lastNumLines+1);
+    std::cout << consoleOutputString.toStdString() << std::endl;
+    lastNumLines = consoleOutputString.count("\n");
 }

--- a/Linux/RControlStation/task_basestation.cpp
+++ b/Linux/RControlStation/task_basestation.cpp
@@ -1,0 +1,8 @@
+#include "task_basestation.h"
+#include <QDebug>
+
+
+void BaseStationTask::task()
+{
+    qDebug() << "hello";
+}

--- a/Linux/RControlStation/task_basestation.cpp
+++ b/Linux/RControlStation/task_basestation.cpp
@@ -34,7 +34,8 @@ void Task_BaseStation::task()
     QString serialPort = "ttyACM0";
     int baudrate = 115200;
     int rate = 1000;
-    double surveyInMinAcc = 2.0;
+    int surveyInMinDuration = 300;
+    double surveyInMinAcc = 1.0;
     double refSendLat = -90;
     double refSendLon = 0;
     double refSendH = -5000;
@@ -49,7 +50,7 @@ void Task_BaseStation::task()
 
     qDebug() << "Serial connection to " << serialPort << " established.";
     mUBXCommTimer.start(500);
-    BaseStation::configureUbx(&mUblox, rate, isF9p, isM8p, mSurveyIn, surveyInMinAcc, &mBasePosSet, refSendLat, refSendLon, refSendH);
+    BaseStation::configureUbx(&mUblox, rate, isF9p, isM8p, &mBasePosSet, refSendLat, refSendLon, refSendH, mSurveyIn, surveyInMinAcc, surveyInMinDuration);
 
     mUblox.ubxPoll(UBX_CLASS_MON, UBX_MON_VER);
     mUblox.ubxPoll(UBX_CLASS_CFG, UBX_CFG_GNSS);    
@@ -174,11 +175,11 @@ void Task_BaseStation::updateConsoleOutput()
 
     QString satInfoString = QString(
         "Satellite Info.\n"
-        "GPS\t-\t%2 / %1   used / visible          \n"
-        "Galileo\t-\t%4 / %3   used / visible          \n"
-        "BeiDou\t-\t%6 / %5   used / visible          \n"
-        "GLONASS\t-\t%8 / %7   used / visible          \n"
-        "Total\t-\t%10 / %9   used / visible         \n"
+        " GPS     -\t%2 / %1   used / visible          \n"
+        " Galileo -\t%4 / %3   used / visible          \n"
+        " BeiDou  -\t%6 / %5   used / visible          \n"
+        " GLONASS -\t%8 / %7   used / visible          \n"
+        " Total   -\t%10 / %9   used / visible         \n"
         "----------------------------------------------------------------------------------------------\n").
             arg(mSatInfo.gpsVisible, 3).
             arg(mSatInfo.gpsUsed, 3).

--- a/Linux/RControlStation/task_basestation.cpp
+++ b/Linux/RControlStation/task_basestation.cpp
@@ -5,6 +5,7 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QSerialPortInfo>
+#include <QNetworkInterface>
 
 #define RTCM_REF_MSG_DELAY_MULT 5
 
@@ -30,20 +31,10 @@ void Task_BaseStation::getExternalIp()
 }
 
 void Task_BaseStation::getInternalIp() {
-    FILE *fp;
-    if ((fp = popen("hostname --all-ip-addresses", "r")) == NULL) {
-        mIntIPstring = "unknown.";
-        return;
-    }
-
-    char buffer[2048];
-    fgets((char*)&buffer, 2048, fp);
-    mIntIPstring = buffer;
-
-    if(pclose(fp))  {
-        mIntIPstring = "unknown.";
-        return;
-    }
+    mIntIPstring = "";
+    for (QHostAddress addr : QNetworkInterface::allAddresses())
+        if (addr.protocol() == QAbstractSocket::IPv4Protocol && !addr.isLoopback())
+            mIntIPstring += QString(addr.toString() + " ");
 }
 
 void Task_BaseStation::task()

--- a/Linux/RControlStation/task_basestation.cpp
+++ b/Linux/RControlStation/task_basestation.cpp
@@ -1,8 +1,33 @@
 #include "task_basestation.h"
+#include "basestation.h"
 #include <QDebug>
 
 
-void BaseStationTask::task()
+void Task_BaseStation::task()
 {
-    qDebug() << "hello";
+//    qDebug() << "hello";
+//    printf("%c[1A", 033); // back one line
+//    printf("test");
+
+    // TODO: parameterize from CLI
+    QString serialPort = "ttyACM0";
+    int baudrate = 115200;
+    int rate = 1000;
+    bool surveyIn = false;
+    double surveyInMinAcc = 2.0;
+    double refSendLat = 0;
+    double refSendLon = 0;
+    double refSendH = 0;
+    bool isM8p = false;
+    bool isF9p = true;
+    bool mBasePosSet = false;
+
+
+    bool res = mUblox.connectSerial(serialPort, baudrate);
+    qDebug() << "Connection to UBX: " << res;
+    if (res) {
+        BaseStation::configureUbx(&mUblox, rate, isF9p, isM8p, surveyIn, surveyInMinAcc, &mBasePosSet, refSendLat, refSendLon, refSendH);
+    }
+
+    emit finished();
 }

--- a/Linux/RControlStation/task_basestation.h
+++ b/Linux/RControlStation/task_basestation.h
@@ -3,17 +3,77 @@
 
 #include "task.h"
 #include "ublox.h"
+#include <QTimer>
+#include <QEventLoop>
+#include <iostream>
+#include <memory>
+#include <QNetworkAccessManager>
+
+typedef struct SatInfo
+{
+    SatInfo() {}
+    int gpsVisible, gloVisible, galVisible, bdsVisible;
+    int gpsUsed, gloUsed, galUsed, bdsUsed;
+} SatInfo;
 
 class Task_BaseStation : public Task
 {
     Q_OBJECT
 public:
-    Task_BaseStation(QObject *parent = 0) : Task(parent) {}
+    Task_BaseStation(QObject *parent = 0) : Task(parent) {
+        //mTcpServer = new TcpBroadcast(this);
+
+        mUBXCommTimer.setSingleShot(true);
+        connect(this, &Task_BaseStation::gotAllInitInfo, &mUBXCommWaitLoop, &QEventLoop::quit);
+        connect(&mUBXCommTimer, &QTimer::timeout, [this]{std::cout << "UBX communication timed out, exiting."; emit finished();});
+
+        connect(&mUblox, &Ublox::rxMonVer, this, &Task_BaseStation::rxMonVer);
+        connect(&mUblox, &Ublox::rxCfgGnss, this, &Task_BaseStation::rxCfgGnss);
+
+        connect(&mUpdateConsoleTimer, &QTimer::timeout, this, &Task_BaseStation::updateConsoleOutput);
+
+    }
+
+signals:
+    void gotAllInitInfo();
+
+private slots:
+    void rxMonVer(QString sw, QString hw, QStringList extensions);
+    void rxCfgGnss(ubx_cfg_gnss cfg);
+    void rxNavSat(ubx_nav_sat satellites);
+    void rxSvin(ubx_nav_svin svin);
+    void rtcmRx(QByteArray data, int type);
+    void updateConsoleOutput();
 
 private:
+    QTimer mUBXCommTimer;
+    QEventLoop mUBXCommWaitLoop;
+    QTimer mUpdateConsoleTimer;
+
     Ublox mUblox;
     QMap<int, int> mRtcmUbx;
+    SatInfo mSatInfo;
+    ubx_nav_svin mLastSvin;
+
+    int mTcpServerPort = 2101;
+    TcpBroadcast mTcpServer;
+
+    std::unique_ptr<QNetworkAccessManager> mNetworkAccessManager;
+
+    bool mBasePosSet = false;
+
+    bool mSurveyIn = true;
+    double mRefSendllh[3];
+
+    QString mMonVerString;
+    QString mCfgGnssString;
+    QString mExtIPstring;
+    bool mPrintMonVer = false;
+    bool mPrintCfgGnss = false;
+    QString consoleOutputString;
+
     void task();
+    void getExternalIp();
 };
 
 #endif // BASESTATIONTASK_H

--- a/Linux/RControlStation/task_basestation.h
+++ b/Linux/RControlStation/task_basestation.h
@@ -2,14 +2,17 @@
 #define BASESTATIONTASK_H
 
 #include "task.h"
+#include "ublox.h"
 
-class BaseStationTask : public Task
+class Task_BaseStation : public Task
 {
     Q_OBJECT
 public:
-    BaseStationTask(QObject *parent = 0) : Task(parent) {}
+    Task_BaseStation(QObject *parent = 0) : Task(parent) {}
 
 private:
+    Ublox mUblox;
+    QMap<int, int> mRtcmUbx;
     void task();
 };
 

--- a/Linux/RControlStation/task_basestation.h
+++ b/Linux/RControlStation/task_basestation.h
@@ -1,0 +1,16 @@
+#ifndef BASESTATIONTASK_H
+#define BASESTATIONTASK_H
+
+#include "task.h"
+
+class BaseStationTask : public Task
+{
+    Q_OBJECT
+public:
+    BaseStationTask(QObject *parent = 0) : Task(parent) {}
+
+private:
+    void task();
+};
+
+#endif // BASESTATIONTASK_H

--- a/Linux/RControlStation/task_basestation.h
+++ b/Linux/RControlStation/task_basestation.h
@@ -76,6 +76,7 @@ private:
     QString mMonVerString;
     QString mCfgGnssString;
     QString mExtIPstring;
+    QString mIntIPstring;
     bool mPrintMonVer = false;
     bool mPrintCfgGnss = false;
     QString consoleOutputString;
@@ -84,6 +85,7 @@ private:
 
     void task();
     void getExternalIp();
+    void getInternalIp();
 };
 
 #endif // BASESTATIONTASK_H

--- a/Linux/RControlStation/tcpbroadcast.h
+++ b/Linux/RControlStation/tcpbroadcast.h
@@ -32,6 +32,7 @@ public:
     explicit TcpBroadcast(QObject *parent = 0);
     ~TcpBroadcast();
     bool startTcpServer(int port);
+    bool isRunning() {return mTcpServer->isListening();}
     QString getLastError();
     void stopServer();
     void broadcastData(QByteArray data);

--- a/Linux/RControlStation/ublox.cpp
+++ b/Linux/RControlStation/ublox.cpp
@@ -992,7 +992,7 @@ void Ublox::ubx_decode(uint8_t msg_class, uint8_t id, uint8_t *msg, int len)
         case UBX_NAV_SVIN:
             ubx_decode_svin(msg, len);
             break;
-        case UBX_NAV_SOL:
+        case UBX_NAV_SOL: // TODO: dropped on F9P, implement UBX-NAV-PVT or UBX-NAV-HPPOSLLH (see: https://cdn.sparkfun.com/assets/learn_tutorials/8/5/6/ZED-F9P_FW_1.00_HPG_1.00_release_notes.pdf)
             ubx_decode_nav_sol(msg, len);
             break;
         case UBX_NAV_SAT:


### PR DESCRIPTION
- add "Task" class that can be registered to Qt main loop to implement commandline-based modes with event loop
- implement basestation as a commandline mode "RControlStation --basestation" that can run on a headless system (does survey-in and then transmits RTCM over TCP)

main goal of this is running, e.g., a raspberry pi as a headless rtk gnss reference station

"Screenshot":
```
RTK Reference Station. Sending RTCM3 on port 2101. External IP: 194.218.146.225         
----------------------------------------------------------------------------------------------
Position  - Lat: 57.71414184   Lon: 12.89052873   Height: 225.674          
Survey-In - Valid: 1   Active: 0   Duration: 841s   Accuracy: 1.9989m   Observations: 842         
----------------------------------------------------------------------------------------------
Satellite Info.
 GPS     -        7 /  12   used / visible          
 Galileo -        4 /   7   used / visible          
 BeiDou  -        5 /   9   used / visible          
 GLONASS -        6 /  10   used / visible          
 Total   -       22 /  38   used / visible         
----------------------------------------------------------------------------------------------
RTCM Transmitted:
 1005 sent:    10   1074 sent:    54   1077 sent:    54   1084 sent:    54   1087 sent:    54   
 1094 sent:    54   1097 sent:    54   1124 sent:    54   1127 sent:    53   1230 sent:    53   
 4072 sent:    53   
```