### PR TITLE
Add default paths for esmini scenario files

### DIFF
--- a/Linux/RControlStation/pagesimscen.cpp
+++ b/Linux/RControlStation/pagesimscen.cpp
@@ -45,6 +45,10 @@ PageSimScen::PageSimScen(QWidget *parent) :
 
 //    Logger::Inst().SetCallback(log_callback);
 
+    // Add default location for scenario files
+    SE_AddPath("esmini/resources/xodr");
+    SE_AddPath("esmini/resources/xosc");
+
     mOdrManager = 0;
     mSimTime = 0.0;
     mStory = new OscStory();


### PR DESCRIPTION
This solves the "path issue". So that original esmini example scenario will work without manipulating paths to xosc, xodr or catalogs.
Note that it depends on a fix on esmini side too (commit [acaffda](https://github.com/esmini/esmini/commit/acaffdac4ff13ec927240ca2100b6be267474902)).

With recent parser updates to support OpenSCENARIO 2.0 it all seems to work great now!